### PR TITLE
Split ap_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ Liquid filter for displaying Associated Press (AP) style time and date values.
 
 ## Usage
 
-The `ap_time` filter applies a date and time formatting in AP style, e.g. `2:23 p.m. Jan. 10, 2015`. It also replaces the time value with `noon` and `midnight` when appropriate.
+The `ap_time` filter returns time formatted in AP style, e.g. `2:23 p.m.`. It enforces rules such as replacing the time value with `noon` and `midnight` when appropriate.
 
 ```
 {{ site.time | ap_time }}
 ```
 
-The `ap_date` filter only displays the date portion, e.g. `Jan. 10, 2015`.
+The `ap_date` filter returns date formatted in AP style, e.g. `Jan. 1, 2015`. It enforces rules such abbreviating the month when appropriate.
 ```
 {{ site.time | ap_date }}
+```
+
+The `ap_time_date` filter combines `ap_time` with `ap_date` formatting, e.g. `2:23 p.m. Jan. 1, 2015`.
+
+```
+{{ site.time | ap_time_date }}
 ```
 
 See the [tests](https://github.com/cityoffortworth/jekyll-ap_style_time/blob/master/test/jekyll/ap_style_time/filter_test.rb) for more details.

--- a/jekyll-ap_style_time.gemspec
+++ b/jekyll-ap_style_time.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
 
   spec.name          = 'jekyll-ap_style_time'
-  spec.version       = '0.0.1'
+  spec.version       = '0.0.2'
   spec.authors       = ['Greg Scott']
   spec.email         = ['me@gregoryjscott.com']
   spec.summary       = %q{Liquid filter for displaying AP style time and date values.}

--- a/lib/jekyll/ap_style_time/filter.rb
+++ b/lib/jekyll/ap_style_time/filter.rb
@@ -11,6 +11,11 @@ module Jekyll
 
       def ap_time(input)
         date = DateTime.parse(input.to_s)
+        format_as_ap_time(date)
+      end
+
+      def ap_time_date(input)
+        date = DateTime.parse(input.to_s)
         date_str = format_as_ap_date(date)
         time_str = format_as_ap_time(date)
         "#{time_str} #{date_str}"

--- a/test/jekyll/ap_style_time/filter_test.rb
+++ b/test/jekyll/ap_style_time/filter_test.rb
@@ -78,23 +78,32 @@ describe Jekyll::APStyleTime::Filter do
 
     it 'displays noon correctly' do
       new_date = filter.ap_time('2015-01-10 12:00:00 -600')
-      assert_equal 'noon Jan. 10, 2015', new_date
+      assert_equal 'noon', new_date
     end
 
     it 'displays midnight correctly' do
       new_date = filter.ap_time('2015-01-10 00:00:00 -600')
-      assert_equal 'midnight Jan. 10, 2015', new_date
+      assert_equal 'midnight', new_date
     end
 
     it 'displays non-noon and non-midnight correctly' do
       new_date = filter.ap_time('2015-01-10 14:23:00 -600')
-      assert_equal '2:23 p.m. Jan. 10, 2015', new_date
+      assert_equal '2:23 p.m.', new_date
     end
 
     it 'omits minutes if zero' do
       new_date = filter.ap_time('2015-01-10 14:00:00 -600')
-      assert_equal '2 p.m. Jan. 10, 2015', new_date
+      assert_equal '2 p.m.', new_date
     end
 
   end
+
+  describe 'when displaying time and date' do
+
+    it 'combines AP time with AP date' do
+      new_date = filter.ap_time_date('2015-01-01 14:23:00 -600')
+      assert_equal '2:23 p.m. Jan. 1, 2015', new_date
+    end
+
+    end
 end


### PR DESCRIPTION
This splits `ap_time` into `ap_time` and `ap_time_date`. This provides for more flexible ways of combining AP time and date values.